### PR TITLE
Make purl work with dot-git-less repos

### DIFF
--- a/src/rebar3_sbom_purl.erl
+++ b/src/rebar3_sbom_purl.erl
@@ -8,27 +8,27 @@ hex(Name, Version) ->
     purl(["hex", string:lowercase(Name)], Version).
 
 git(_Name, "git@github.com:" ++ Github, Ref) ->
-    [Repo, _, _] = string:replace(Github, ".git", "", trailing),
+    Repo = string:replace(Github, ".git", "", trailing),
     github(Repo, Ref);
 
 git(_Name, "https://github.com/" ++ Github, Ref) ->
-    [Repo, _, _] = string:replace(Github, ".git", "", trailing),
+    Repo = string:replace(Github, ".git", "", trailing),
     github(Repo, Ref);
 
 git(_Name, "git://github.com/" ++ Github, Ref) ->
-    [Repo, _, _] = string:replace(Github, ".git", "", trailing),
+    Repo = string:replace(Github, ".git", "", trailing),
     github(Repo, Ref);
 
 git(_Name, "git@bitbucket.org:" ++ Github, Ref) ->
-    [Repo, _, _] = string:replace(Github, ".git", "", trailing),
+    Repo = string:replace(Github, ".git", "", trailing),
     bitbucket(Repo, Ref);
 
 git(_Name, "https://bitbucket.org/" ++ Github, Ref) ->
-    [Repo, _, _] = string:replace(Github, ".git", "", trailing),
+    Repo = string:replace(Github, ".git", "", trailing),
     bitbucket(Repo, Ref);
 
 git(_Name, "git://bitbucket.org/" ++ Github, Ref) ->
-    [Repo, _, _] = string:replace(Github, ".git", "", trailing),
+    Repo = string:replace(Github, ".git", "", trailing),
     bitbucket(Repo, Ref);
 
 %% Git dependence other than GitHub and BitBucket are not currently supported


### PR DESCRIPTION
The result of `string:replace/4` is essentially a _string_ itself anyway, there's no need for additional pattern matching.

With this patch the plugin no longer crashes on URLs like `https://github.com/potatosalad/erlang-libdecaf`.

As of rbkmoney/rebar3_sbom#1.