### PR TITLE
Release v0.6.0

### DIFF
--- a/src/rebar3_sbom.app.src
+++ b/src/rebar3_sbom.app.src
@@ -1,6 +1,6 @@
 {application, rebar3_sbom,
  [{description, "Rebar3 plugin to generate CycloneDX SBoM"},
-  {vsn, "0.5.1"},
+  {vsn, "0.6.0"},
   {registered, []},
   {applications,
    [kernel,


### PR DESCRIPTION
Changes:

* Support newer Rebar3 pkg tuples (#5)
* Replace `http_uri` with `uri_string`, to support OTP 25 (#7)

Now requires OTP 21 or later
