### PR TITLE
Fix build on OTP<25

### DIFF
--- a/src/rebar3_sbom_purl.erl
+++ b/src/rebar3_sbom_purl.erl
@@ -44,5 +44,17 @@ bitbucket(Repo, Ref) ->
     purl(["bitbucket", string:lowercase(Organization), string:lowercase(Name)], Ref).
 
 purl(PathSegments, Version) ->
-    Path = lists:join("/", [uri_string:quote(Segment) || Segment <- PathSegments]),
-    io_lib:format("pkg:~s@~s", [Path, uri_string:quote(Version)]).
+    Path = lists:join("/", [escape(Segment) || Segment <- PathSegments]),
+    io_lib:format("pkg:~s@~s", [Path, escape(Version)]).
+
+-if(?OTP_RELEASE >= 25).
+
+escape(String) ->
+    uri_string:quote(String).
+
+-else.
+
+escape(String) ->
+    http_uri:encode(String).
+
+-endif.


### PR DESCRIPTION
Turns out, `uri_string` module was added in OTP21, but `quote/1` was not added until OTP25