### PR TITLE
fix output error

### DIFF
--- a/src/rebar3_sbom_cyclonedx.erl
+++ b/src/rebar3_sbom_cyclonedx.erl
@@ -35,6 +35,7 @@ component(Component) ->
             lists:member(Field, ?COMPONENT_FIELDS), Value /= undefined, Value /= []]}.
 
 component_field(name, Name) -> {name, [], [[Name]]};
+component_field(version, Version) when is_atom(Version) -> {version, [], [[atom_to_binary(Version)]]};
 component_field(version, Version) -> {version, [], [[Version]]};
 component_field(author, Author) -> {author, [], [[string:join(Author, ",")]]};
 component_field(description, Description) -> {description, [], [[Description]]};


### PR DESCRIPTION
I was testing the plugin in one of the repositories at work. We would like to use the plugin and we are a big company with more than 300 repositories. There was an error if the version in app.src tuple is an atom e.x {vsn, git}.

These are the logs from rebar3:

```
===> Uncaught error: badarg
===> Stack trace to the error location:
[{erlang,binary_to_list,[git],[]},
 {xmerl_lib,export_text,2,[{file,"xmerl_lib.erl"},{line,69}]},
 {xmerl,export_content,2,[{file,"xmerl.erl"},{line,191}]},
 {xmerl,export_element,2,[{file,"xmerl.erl"},{line,224}]},
 {xmerl,export_content,2,[{file,"xmerl.erl"},{line,199}]},
 {xmerl,export_content,2,[{file,"xmerl.erl"},{line,199}]},
 {xmerl,export_element,2,[{file,"xmerl.erl"},{line,224}]},
 {xmerl,export_content,2,[{file,"xmerl.erl"},{line,199}]}]
```