### PR TITLE
Add support for generating JSON output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ _build
 rebar3.crashdump
 doc/
 bom.xml
+bom.json

--- a/README.md
+++ b/README.md
@@ -19,9 +19,12 @@ Then run the 'sbom' task on a project:
 
 The following command line options are supported:
 
-    -o, --output  the full path to the SBoM output file [default: bom.xml]
+    -F, --format  the file format of the SBoM output, [xml|json], [default: xml]
+    -o, --output  the full path to the SBoM output file [default: ./bom.[xml|json]]
     -f, --force   overwite existing files without prompting for confirmation
                   [default: false]
+    -V, --strict_version modify the version number of the bom only when the content changes
+                  [default: true]
 
 By default only dependencies in the 'default' profile are included. To
 generate an SBoM covering development environments specify the relevant

--- a/include/rebar3_sbom.hrl
+++ b/include/rebar3_sbom.hrl
@@ -1,0 +1,36 @@
+-define(APP, "rebar3_sbom").
+-define(DEFAULT_OUTPUT, "./bom.xml").
+-define(DEFAULT_VERSION, 1).
+-define(PROVIDER, sbom).
+-define(DEPS, [lock]).
+
+-record(metadata, {
+    timestamp :: string(),
+    tools = [] :: [string()]
+}).
+
+-record(component, {
+    type = "library",
+    bom_ref :: string(),
+    author :: string(),
+    name :: string(),
+    version :: string(),
+    description :: string(),
+    hashes :: [#{alg := string(), hash := string()}],
+    licenses :: [#{name := string()} | #{id := string()}],
+    purl :: string()
+}).
+
+-record(dependency, {
+    ref :: string(),
+    dependencies = [] :: [#dependency{}]
+}).
+
+-record(sbom, {
+    format = "CycloneDX" :: string(),
+    version = ?DEFAULT_VERSION :: integer(),
+    serial :: string(),
+    metadata :: #metadata{},
+    components :: [#component{}],
+    dependencies :: [#dependency{}]
+}).

--- a/include/rebar3_sbom.hrl
+++ b/include/rebar3_sbom.hrl
@@ -1,5 +1,5 @@
 -define(APP, "rebar3_sbom").
--define(DEFAULT_OUTPUT, "./bom.xml").
+-define(DEFAULT_OUTPUT, "./bom.[xml|json]").
 -define(DEFAULT_VERSION, 1).
 -define(PROVIDER, sbom).
 -define(DEPS, [lock]).

--- a/src/rebar3_sbom_cyclonedx.erl
+++ b/src/rebar3_sbom_cyclonedx.erl
@@ -114,6 +114,10 @@ version({FilePath, Format}, IsStrictVersion, NewSbom) ->
             OldSbom = decode(FilePath, Format),
             version(IsStrictVersion, {NewSbom, OldSbom});
         false ->
+            rebar_api:info(
+                "Using default SBOM version ~p: no previous SBOM file found.",
+                [?DEFAULT_VERSION]
+            ),
             ?DEFAULT_VERSION
     end.
 
@@ -122,14 +126,27 @@ version({FilePath, Format}, IsStrictVersion, NewSbom) ->
     NewSbom :: #sbom{}, OldSbom :: #sbom{},
     Version :: integer().
 version(_, {_, OldSbom}) when OldSbom#sbom.version =:= 0 ->
+    rebar_api:info(
+        "Using default SBOM version ~p: invalid version in previous SBOM file.",
+        [?DEFAULT_VERSION]
+    ),
     ?DEFAULT_VERSION;
 version(IsStrictVersion, {_, OldSbom}) when IsStrictVersion =:= false ->
+    rebar_api:info(
+        "Incrementing the SBOM version unconditionally: strict_version is set to false.", []
+    ),
     OldSbom#sbom.version + 1;
 version(IsStrictVersion, {NewSbom, OldSbom}) when IsStrictVersion =:= true ->
     case is_sbom_equal(NewSbom, OldSbom) of
         true ->
+            rebar_api:info(
+                "Not incrementing the SBOM version: new SBOM is equivalent to the old SBOM.", []
+            ),
             OldSbom#sbom.version;
         false ->
+            rebar_api:info(
+                "Incrementing the SBOM version: new SBOM is not equivalent to the old SBOM.", []
+            ),
             OldSbom#sbom.version + 1
     end.
 

--- a/src/rebar3_sbom_cyclonedx.erl
+++ b/src/rebar3_sbom_cyclonedx.erl
@@ -108,46 +108,46 @@ bom_ref_of_component(RawComponent) ->
     Name = proplists:get_value(name, RawComponent),
     lists:flatten(io_lib:format("ref_component_~ts", [Name])).
 
-version({FilePath, Format}, IsStrictVersion, NewSbom) ->
+version({FilePath, Format}, IsStrictVersion, NewSBoM) ->
     case filelib:is_regular(FilePath) of
         true ->
-            OldSbom = decode(FilePath, Format),
-            version(IsStrictVersion, {NewSbom, OldSbom});
+            OldSBoM = decode(FilePath, Format),
+            version(IsStrictVersion, {NewSBoM, OldSBoM});
         false ->
             rebar_api:info(
-                "Using default SBOM version ~p: no previous SBOM file found.",
+                "Using default SBoM version ~p: no previous SBoM file found.",
                 [?DEFAULT_VERSION]
             ),
             ?DEFAULT_VERSION
     end.
 
--spec version(IsStrictVersion, {NewSbom, OldSbom}) -> Version when
+-spec version(IsStrictVersion, {NewSBoM, OldSBoM}) -> Version when
     IsStrictVersion :: boolean(),
-    NewSbom :: #sbom{}, OldSbom :: #sbom{},
+    NewSBoM :: #sbom{}, OldSBoM :: #sbom{},
     Version :: integer().
-version(_, {_, OldSbom}) when OldSbom#sbom.version =:= 0 ->
+version(_, {_, OldSBoM}) when OldSBoM#sbom.version =:= 0 ->
     rebar_api:info(
-        "Using default SBOM version ~p: invalid version in previous SBOM file.",
+        "Using default SBoM version ~p: invalid version in previous SBoM file.",
         [?DEFAULT_VERSION]
     ),
     ?DEFAULT_VERSION;
-version(IsStrictVersion, {_, OldSbom}) when IsStrictVersion =:= false ->
+version(IsStrictVersion, {_, OldSBoM}) when IsStrictVersion =:= false ->
     rebar_api:info(
-        "Incrementing the SBOM version unconditionally: strict_version is set to false.", []
+        "Incrementing the SBoM version unconditionally: strict_version is set to false.", []
     ),
-    OldSbom#sbom.version + 1;
-version(IsStrictVersion, {NewSbom, OldSbom}) when IsStrictVersion =:= true ->
-    case is_sbom_equal(NewSbom, OldSbom) of
+    OldSBoM#sbom.version + 1;
+version(IsStrictVersion, {NewSBoM, OldSBoM}) when IsStrictVersion =:= true ->
+    case is_sbom_equal(NewSBoM, OldSBoM) of
         true ->
             rebar_api:info(
-                "Not incrementing the SBOM version: new SBOM is equivalent to the old SBOM.", []
+                "Not incrementing the SBoM version: new SBoM is equivalent to the old SBoM.", []
             ),
-            OldSbom#sbom.version;
+            OldSBoM#sbom.version;
         false ->
             rebar_api:info(
-                "Incrementing the SBOM version: new SBOM is not equivalent to the old SBOM.", []
+                "Incrementing the SBoM version: new SBoM is not equivalent to the old SBoM.", []
             ),
-            OldSbom#sbom.version + 1
+            OldSBoM#sbom.version + 1
     end.
 
 is_sbom_equal(#sbom{components = NewComponents}, #sbom{components = OldComponents}) ->

--- a/src/rebar3_sbom_cyclonedx.erl
+++ b/src/rebar3_sbom_cyclonedx.erl
@@ -2,55 +2,84 @@
 
 -export([bom/3, bom/4, uuid/0]).
 
--define(APP, "rebar3_sbom").
--define(DEFAULT_VERSION, "1").
--define(COMPONENT_FIELDS, [name, version, author, description, licenses, purl, sha256]).
+-include("rebar3_sbom.hrl").
 
--include_lib("xmerl/include/xmerl.hrl").
+bom(File, IsStrictVersion, RawComponents) ->
+    bom(File, IsStrictVersion, RawComponents, uuid()).
 
-bom(File, Components, Opts) ->
-    bom(File, Components, Opts, uuid()).
-
-bom(File, Components, Opts, Serial) ->
-    ValidComponents = lists:filter(fun(E) -> E =/= undefined end, Components),
-    Content = {bom, [{version, ?DEFAULT_VERSION},
-                     {serialNumber, Serial},
-                     {xmlns, "http://cyclonedx.org/schema/bom/1.4"}],
-               [{metadata, metadata()},
-                {components, [], [component(Component) || Component <- ValidComponents]},
-                {dependencies, [], [dependency(Component) || Component <- ValidComponents]}]},
-    Normalized = xmerl_lib:normalize_element(Content),
-    Bom = update_version(File, Normalized, Opts),
-    xmerl:export_simple([Bom], xmerl_xml).
+bom(File, IsStrictVersion, RawComponents, Serial) ->
+    ValidRawComponents = lists:filter(fun(E) -> E =/= undefined end, RawComponents),
+    SBoM = #sbom{
+        serial = Serial,
+        metadata = metadata(),
+        components = components(ValidRawComponents),
+        dependencies = dependencies(ValidRawComponents)
+    },
+    try
+        V = version(File, IsStrictVersion, SBoM),
+        SBoM#sbom{version = V}
+    catch _:Reason ->
+        logger:error("scan file:~ts failed, reason:~p, will use the default version number ~p",
+                     [File, Reason, ?DEFAULT_VERSION]),
+        SBoM
+    end.
 
 metadata() ->
-    [{timestamp, [calendar:system_time_to_rfc3339(erlang:system_time(second))]},
-     {tools, [{tool, [{name, [?APP]}]}]}
-    ].
+    #metadata{
+        timestamp = calendar:system_time_to_rfc3339(erlang:system_time(second)),
+        tools = [?APP]
+    }.
 
-component(Component) ->
-    {component, [{type, "library"}, {'bom-ref', bom_ref_of_component(Component)}],
-        [component_field(Field, Value)
-         || {Field, Value} <- Component,
-            lists:member(Field, ?COMPONENT_FIELDS), Value /= undefined, Value /= []]}.
+components(RawComponents) ->
+    [component(RawComponent) || RawComponent <- RawComponents].
 
-component_field(name, Name) -> {name, [], [[Name]]};
-component_field(version, Version) -> {version, [], [[Version]]};
-component_field(author, Author) -> {author, [], [[string:join(Author, ",")]]};
-component_field(description, Description) -> {description, [], [[Description]]};
-component_field(licenses, Licenses) -> {licenses, [], [license(License) || License <- Licenses]};
-component_field(purl, Purl) -> {purl, [], [[Purl]]};
-component_field(sha256, Sha256) ->
-    {hashes, [], [
-        {hash, [{alg, "SHA-256"}], [[Sha256]]}
-    ]}.
+component(RawComponent) ->
+    #component{
+        bom_ref = bom_ref_of_component(RawComponent),
+        name = component_field(name, RawComponent),
+        author = component_field(author, RawComponent),
+        version = component_field(version, RawComponent),
+        description = component_field(description, RawComponent),
+        hashes = component_field(sha256, RawComponent),
+        licenses = component_field(licenses, RawComponent),
+        purl = component_field(purl, RawComponent)
+    }.
+
+component_field(author = Field, RawComponent) ->
+    case proplists:get_value(Field, RawComponent) of
+        undefined ->
+            undefined;
+        Value ->
+            string:join(Value, ",")
+    end;
+component_field(licenses = Field, RawComponent) ->
+    case proplists:get_value(Field, RawComponent) of
+        undefined ->
+            undefined;
+        Licenses ->
+            [license(License) || License <- Licenses]
+    end;
+component_field(sha256 = Field, RawComponent) ->
+    case proplists:get_value(Field, RawComponent) of
+        undefined ->
+            undefined;
+        Hash ->
+            [#{alg => "SHA-256", hash => binary:bin_to_list(Hash)}]
+    end;
+component_field(Field, RawComponent) ->
+    case proplists:get_value(Field, RawComponent) of
+        Value when is_binary(Value) ->
+            binary:bin_to_list(Value);
+        Else ->
+            Else
+    end.
 
 license(Name) ->
     case rebar3_sbom_license:spdx_id(Name) of
         undefined ->
-            {license, [], [{name, [], [[Name]]}]};
+            #{name => Name};
         SpdxId ->
-            {license, [], [{id, [], [[SpdxId]]}]}
+            #{id => SpdxId}
     end.
 
 uuid() ->
@@ -60,61 +89,48 @@ uuid() ->
 hex(Bin) ->
     string:lowercase(<< <<Hex>> || <<Nibble:4>> <= Bin, Hex <- integer_to_list(Nibble,16) >>).
 
-update_version(File, #xmlElement{attributes = Attrs} = Bom, Opts) ->
-    Version = get_version(File, Bom, Opts),
-    Attr = lists:keyfind(version, #xmlAttribute.name, Attrs),
-    NewAttr = Attr#xmlAttribute{value = Version},
-    NewAttrs = lists:keyreplace(version, #xmlAttribute.name, Attrs, NewAttr),
-    Bom#xmlElement{attributes = NewAttrs}.
+dependencies(undefined) ->
+    [];
+dependencies(RawComponents) ->
+    [dependency(RawComponent) || RawComponent <- RawComponents].
 
-get_version(File, Bom, Opts) ->
-    try
-        case xmerl_scan:file(File) of
-            {#xmlElement{attributes = Attrs} = Old, _} ->
-                case lists:keyfind(version, #xmlAttribute.name, Attrs) of
-                    false ->
-                        ?DEFAULT_VERSION;
-                    #xmlAttribute{value = Value} ->
-                        case is_strict_version(Opts) andalso is_bom_equal(Old, Bom) of
-                            true ->
-                                Value;
-                            _ ->
-                                Version = erlang:list_to_integer(Value),
-                                erlang:integer_to_list(Version + 1)
-                        end
-                end;
-            {error, enoent} ->
-                ?DEFAULT_VERSION
-        end
-    catch _:Reason ->
-            logger:error("scan file:~ts failed, reason:~p, will use the default version number 1",
-                         [File, Reason]),
+dependency(RawComponent) ->
+    RawDependencies = proplists:get_value(dependencies, RawComponent, []),
+    #dependency{
+        ref = bom_ref_of_component(RawComponent),
+        dependencies = [
+            dependency([{name, D}]) || D <- RawDependencies
+        ]
+    }.
+
+bom_ref_of_component(RawComponent) ->
+    Name = proplists:get_value(name, RawComponent),
+    lists:flatten(io_lib:format("ref_component_~ts", [Name])).
+
+version(File, IsStrictVersion, NewSbom) ->
+    case filelib:is_regular(File) of
+        true ->
+            OldSbom = rebar3_sbom_xml:decode(File),
+            version(IsStrictVersion, {NewSbom, OldSbom});
+        false ->
             ?DEFAULT_VERSION
     end.
 
-is_strict_version(Opts) ->
-    proplists:get_value(strict_version, Opts, true).
+-spec version(IsStrictVersion, {NewSbom, OldSbom}) -> Version when
+    IsStrictVersion :: boolean(),
+    NewSbom :: #sbom{}, OldSbom :: #sbom{},
+    Version :: integer().
+version(_, {_, OldSbom}) when OldSbom#sbom.version =:= 0 ->
+    ?DEFAULT_VERSION;
+version(IsStrictVersion, {_, OldSbom}) when IsStrictVersion =:= false ->
+    OldSbom#sbom.version + 1;
+version(IsStrictVersion, {NewSbom, OldSbom}) when IsStrictVersion =:= true ->
+    case is_sbom_equal(NewSbom, OldSbom) of
+        true  -> OldSbom#sbom.version;
+        false -> OldSbom#sbom.version + 1
+    end.
 
-is_bom_equal(#xmlElement{content = A}, #xmlElement{content = B}) ->
-    lists:all(fun(Key) ->
-                      ValA = lists:keyfind(Key, #xmlElement.name, A),
-                      ValB = lists:keyfind(Key, #xmlElement.name, B),
-                      case {ValA, ValB} of
-                          {false, false} -> true;
-                          {false, _} -> false;
-                          {_, false} -> false;
-                          {_, _} ->
-                              xmerl_lib:simplify_element(ValA) =:=
-                                  xmerl_lib:simplify_element(ValB)
-                      end
-              end,
-              [components]).
-
-dependency(Component) ->
-    Ref = bom_ref_of_component(Component),
-    Deps = proplists:get_value(dependencies, Component, []),
-    {dependency, [{ref, [Ref]}], [dependency([{name, Dep}]) || Dep <- Deps]}.
-
-bom_ref_of_component(Component) ->
-    Name = proplists:get_value(name, Component),
-    lists:flatten(io_lib:format("ref_component_~ts", [Name])).
+is_sbom_equal(#sbom{components = NewComponents}, #sbom{components = OldComponents}) ->
+    lists:all(fun(C) -> lists:member(C, NewComponents) end, OldComponents)
+    andalso
+    lists:all(fun(C) -> lists:member(C, OldComponents) end, NewComponents).

--- a/src/rebar3_sbom_cyclonedx.erl
+++ b/src/rebar3_sbom_cyclonedx.erl
@@ -84,7 +84,8 @@ license(Name) ->
 
 uuid() ->
     [A, B, C, D, E] = [crypto:strong_rand_bytes(Len) || Len <- [4, 2, 2, 2, 6]],
-    lists:join("-", [hex(Part) || Part <- [A, B, <<4:4, C:12/binary-unit:1>>, <<2:2, D:14/binary-unit:1>>, E]]).
+    UUID = lists:join("-", [hex(Part) || Part <- [A, B, <<4:4, C:12/binary-unit:1>>, <<2:2, D:14/binary-unit:1>>, E]]),
+    "urn:uuid:" ++ UUID.
 
 hex(Bin) ->
     string:lowercase(<< <<Hex>> || <<Nibble:4>> <= Bin, Hex <- integer_to_list(Nibble,16) >>).

--- a/src/rebar3_sbom_json.erl
+++ b/src/rebar3_sbom_json.erl
@@ -12,7 +12,7 @@ encode(SBoM) ->
     jsone:encode(Content, [native_forward_slash, native_utf8, canonical_form]).
 
 decode(FilePath) ->
-    % Note: This sets the SBOM version to 0 if the json file
+    % Note: This sets the SBoM version to 0 if the json file
     %       does not have a valid version.
     {ok, File} = file:read_file(FilePath),
     JsonTerm = jsone:decode(File),
@@ -21,19 +21,19 @@ decode(FilePath) ->
     #sbom{version = Version, components = Components}.
 
 % Encode -----------------------------------------------------------------------
-sbom_to_json(#sbom{metadata = Metadata} = SBOM) ->
+sbom_to_json(#sbom{metadata = Metadata} = SBoM) ->
     #{
         '$schema' => ?SCHEMA,
-        bomFormat => bin(SBOM#sbom.format),
+        bomFormat => bin(SBoM#sbom.format),
         specVersion => ?SPEC_VERSION,
-        serialNumber => bin(SBOM#sbom.serial),
-        version => SBOM#sbom.version,
+        serialNumber => bin(SBoM#sbom.serial),
+        version => SBoM#sbom.version,
         metadata => #{
             timestamp => bin(Metadata#metadata.timestamp),
             tools => [#{name => bin(T)} || T <- Metadata#metadata.tools]
         },
-        components => [component_to_json(C) || C <- SBOM#sbom.components],
-        dependencies => [dependency_to_json(D) || D <- SBOM#sbom.dependencies]
+        components => [component_to_json(C) || C <- SBoM#sbom.components],
+        dependencies => [dependency_to_json(D) || D <- SBoM#sbom.dependencies]
     }.
 
 component_to_json(C) ->

--- a/src/rebar3_sbom_json.erl
+++ b/src/rebar3_sbom_json.erl
@@ -1,0 +1,135 @@
+-module(rebar3_sbom_json).
+
+-export([encode/1, decode/1]).
+
+-include("rebar3_sbom.hrl").
+
+-define(SPEC_VERSION, <<"1.4">>).
+-define(SCHEMA, <<"http://cyclonedx.org/schema/bom-1.4.schema.json">>).
+
+encode(SBoM) ->
+    Content = sbom_to_json(SBoM),
+    jsone:encode(Content, [native_forward_slash, native_utf8, canonical_form]).
+
+decode(FilePath) ->
+    % Note: This sets the SBOM version to 0 if the json file
+    %       does not have a valid version.
+    {ok, File} = file:read_file(FilePath),
+    JsonTerm = jsone:decode(File),
+    Version = maps:get(<<"version">>, JsonTerm, 0),
+    Components = json_to_components(maps:get(<<"components">>, JsonTerm, [])),
+    #sbom{version = Version, components = Components}.
+
+% Encode -----------------------------------------------------------------------
+sbom_to_json(#sbom{metadata = Metadata} = SBOM) ->
+    #{
+        '$schema' => ?SCHEMA,
+        bomFormat => bin(SBOM#sbom.format),
+        specVersion => ?SPEC_VERSION,
+        serialNumber => bin(SBOM#sbom.serial),
+        version => SBOM#sbom.version,
+        metadata => #{
+            timestamp => bin(Metadata#metadata.timestamp),
+            tools => [#{name => bin(T)} || T <- Metadata#metadata.tools]
+        },
+        components => [component_to_json(C) || C <- SBOM#sbom.components],
+        dependencies => [dependency_to_json(D) || D <- SBOM#sbom.dependencies]
+    }.
+
+component_to_json(C) ->
+    prune_content(#{
+        type => bin(C#component.type),
+        'bom-ref' => bin(C#component.bom_ref),
+        author => bin(C#component.author),
+        name => bin(C#component.name),
+        version => bin(C#component.version),
+        description => bin(C#component.description),
+        hashes => hashes_to_json(C#component.hashes),
+        licenses => licenses_to_json(C#component.licenses),
+        purl => bin(C#component.purl)
+    }).
+
+prune_content(Component) ->
+    maps:filter(fun(_, Value) -> Value =/= undefined end, Component).
+
+hashes_to_json(undefined) ->
+    undefined;
+hashes_to_json(Hashes) ->
+    [hash_to_json(H) || H <- Hashes].
+
+hash_to_json(#{alg := Alg, hash := Hash}) ->
+    #{alg => bin(Alg), content => bin(Hash)}.
+
+licenses_to_json(undefined) ->
+    undefined;
+licenses_to_json(Licenses) ->
+    [license_to_json(L) || L <- Licenses].
+
+license_to_json(#{name := Name}) ->
+    #{license => #{name => bin(Name)}};
+license_to_json(#{id := Id}) ->
+    #{license => #{id => bin(Id)}}.
+
+dependency_to_json(D) ->
+    #{
+        ref => bin(D#dependency.ref),
+        dependsOn => [
+            bin(SubD#dependency.ref) || SubD <- D#dependency.dependencies
+        ]
+    }.
+
+bin(undefined) ->
+    undefined;
+bin(Value) when is_list(Value) ->
+    erlang:list_to_binary(Value);
+bin(Value) ->
+    Value.
+
+% Decode -----------------------------------------------------------------------
+json_to_components(Components) when is_list(Components) ->
+    lists:map(fun json_to_components/1, Components);
+json_to_components(C) ->
+    #component{
+        bom_ref = json_to_component_field(<<"bom-ref">>, C),
+        author = json_to_component_field(<<"author">>, C),
+        description = json_to_component_field(<<"description">>, C),
+        hashes = json_to_component_field(<<"hashes">>, C),
+        licenses = json_to_component_field(<<"licenses">>, C),
+        name = json_to_component_field(<<"name">>, C),
+        purl = json_to_component_field(<<"purl">>, C),
+        type = json_to_component_field(<<"type">>, C),
+        version = json_to_component_field(<<"version">>, C)
+    }.
+
+json_to_component_field(<<"hashes">> = F, Component) ->
+    json_to_hashes(maps:get(F, Component, undefined));
+json_to_component_field(<<"licenses">> = F, Component) ->
+    json_to_licenses(maps:get(F, Component, undefined));
+json_to_component_field(FieldName, Component) ->
+    str(maps:get(FieldName, Component, undefined)).
+
+json_to_hashes(undefined) ->
+    undefined;
+json_to_hashes(Hashes) ->
+    [json_to_hash(H) || H <- Hashes].
+
+json_to_hash(#{<<"alg">> := Alg, <<"content">> := Content}) ->
+    #{alg => str(Alg), hash => str(Content)}.
+
+json_to_licenses(undefined) ->
+    undefined;
+json_to_licenses(Licenses) ->
+    [json_to_license(L) || L <- Licenses].
+
+json_to_license(#{<<"license">> := #{<<"id">> := Id}}) ->
+    #{id => str(Id)};
+json_to_license(#{<<"license">> := #{<<"name">> := Name}}) ->
+    #{name => str(Name)}.
+
+
+str(undefined) ->
+    undefined;
+str(Value) when is_binary(Value) ->
+    erlang:binary_to_list(Value);
+str(Value) ->
+    Value.

--- a/src/rebar3_sbom_prv.erl
+++ b/src/rebar3_sbom_prv.erl
@@ -37,10 +37,10 @@ do(State) ->
     FilePath = filepath(Output, Format),
     Deps = rebar_state:all_deps(State),
     DepsInfo = [dep_info(Dep) || Dep <- Deps],
-    SBOM = rebar3_sbom_cyclonedx:bom({FilePath, Format}, IsStrictVersion, DepsInfo),
+    SBoM = rebar3_sbom_cyclonedx:bom({FilePath, Format}, IsStrictVersion, DepsInfo),
     Contents = case Format of
-        "xml" -> rebar3_sbom_xml:encode(SBOM);
-        "json" -> rebar3_sbom_json:encode(SBOM)
+        "xml" -> rebar3_sbom_xml:encode(SBoM);
+        "json" -> rebar3_sbom_json:encode(SBoM)
     end,
     case write_file(FilePath, Contents, Force) of
         ok ->

--- a/src/rebar3_sbom_xml.erl
+++ b/src/rebar3_sbom_xml.erl
@@ -13,9 +13,9 @@ encode(SBOM) ->
     Content = sbom_to_xml(SBOM),
     xmerl:export_simple([Content], xmerl_xml).
 
-% Note: This sets the SBOM version to 0 if the xml file
-% does not have a valid version.
 decode(FilePath) ->
+    % Note: This sets the SBOM version to 0 if the xml file
+    %       does not have a valid version.
     {SBoM, _} = xmerl_scan:file(FilePath),
     Version = xml_to_bom_version(SBoM, 0),
     Components = [
@@ -23,6 +23,7 @@ decode(FilePath) ->
     ],
     #sbom{version = Version, components = Components}.
 
+% Encode -----------------------------------------------------------------------
 xml_to_bom_version(Xml, Default) ->
     case xpath("/bom/@version", Xml) of
         [Attr] ->
@@ -93,6 +94,7 @@ dependency_to_xml(Dependency) ->
         [dependency_to_xml(D) || D <- Dependency#dependency.dependencies]
     }.
 
+% Decode -----------------------------------------------------------------------
 xml_to_component(Component) ->
     [#xmlAttribute{value = Type}] = xpath("/component/@type", Component),
     [#xmlAttribute{value = BomRef}] = xpath("/component/@bom-ref", Component),

--- a/src/rebar3_sbom_xml.erl
+++ b/src/rebar3_sbom_xml.erl
@@ -9,12 +9,12 @@
 -define(XMLNS_XSI, "http://www.w3.org/2001/XMLSchema-instance").
 -define(XSI_SCHEMA_LOC, "http://cyclonedx.org/schema/bom/1.4 https://cyclonedx.org/schema/bom-1.4.xsd").
 
-encode(SBOM) ->
-    Content = sbom_to_xml(SBOM),
+encode(SBoM) ->
+    Content = sbom_to_xml(SBoM),
     xmerl:export_simple([Content], xmerl_xml).
 
 decode(FilePath) ->
-    % Note: This sets the SBOM version to 0 if the xml file
+    % Note: This sets the SBoM version to 0 if the xml file
     %       does not have a valid version.
     {SBoM, _} = xmerl_scan:file(FilePath),
     Version = xml_to_bom_version(SBoM, 0),
@@ -32,14 +32,14 @@ xml_to_bom_version(Xml, Default) ->
             Default
     end.
 
-sbom_to_xml(#sbom{metadata = Metadata} = SBOM) ->
+sbom_to_xml(#sbom{metadata = Metadata} = SBoM) ->
     {
         bom, [
             {xmlns, ?XMLNS},
             {'xmlns:xsi', ?XMLNS_XSI},
             {'xsi:schemaLocation', ?XSI_SCHEMA_LOC},
-            {version, SBOM#sbom.version},
-            {serialNumber, SBOM#sbom.serial}
+            {version, SBoM#sbom.version},
+            {serialNumber, SBoM#sbom.serial}
         ],
         [
             {metadata, [
@@ -48,8 +48,8 @@ sbom_to_xml(#sbom{metadata = Metadata} = SBOM) ->
                     [tool_to_xml(Tool) || Tool <- Metadata#metadata.tools]
                 }
             ]},
-            {components, [component_to_xml(C) || C <- SBOM#sbom.components]},
-            {dependencies, [dependency_to_xml(D) || D <- SBOM#sbom.dependencies]}
+            {components, [component_to_xml(C) || C <- SBoM#sbom.components]},
+            {dependencies, [dependency_to_xml(D) || D <- SBoM#sbom.dependencies]}
         ]
     }.
 

--- a/src/rebar3_sbom_xml.erl
+++ b/src/rebar3_sbom_xml.erl
@@ -1,0 +1,142 @@
+-module(rebar3_sbom_xml).
+
+-export([encode/1, decode/1]).
+
+-include("rebar3_sbom.hrl").
+-include_lib("xmerl/include/xmerl.hrl").
+
+-define(XMLNS, "http://cyclonedx.org/schema/bom/1.4").
+-define(XMLNS_XSI, "http://www.w3.org/2001/XMLSchema-instance").
+-define(XSI_SCHEMA_LOC, "http://cyclonedx.org/schema/bom/1.4 https://cyclonedx.org/schema/bom-1.4.xsd").
+
+encode(SBOM) ->
+    Content = sbom_to_xml(SBOM),
+    xmerl:export_simple([Content], xmerl_xml).
+
+% Note: This sets the SBOM version to 0 if the xml file
+% does not have a valid version.
+decode(FilePath) ->
+    {SBoM, _} = xmerl_scan:file(FilePath),
+    Version = xml_to_bom_version(SBoM, 0),
+    Components = [
+        xml_to_component(C) || C <- xpath("/bom/components/component", SBoM)
+    ],
+    #sbom{version = Version, components = Components}.
+
+xml_to_bom_version(Xml, Default) ->
+    case xpath("/bom/@version", Xml) of
+        [Attr] ->
+            erlang:list_to_integer(Attr#xmlAttribute.value);
+        [] ->
+            Default
+    end.
+
+sbom_to_xml(#sbom{metadata = Metadata} = SBOM) ->
+    {
+        bom, [
+            {xmlns, ?XMLNS},
+            {'xmlns:xsi', ?XMLNS_XSI},
+            {'xsi:schemaLocation', ?XSI_SCHEMA_LOC},
+            {version, SBOM#sbom.version},
+            {serialNumber, SBOM#sbom.serial}
+        ],
+        [
+            {metadata, [
+                {timestamp, [Metadata#metadata.timestamp]},
+                {tools,
+                    [tool_to_xml(Tool) || Tool <- Metadata#metadata.tools]
+                }
+            ]},
+            {components, [component_to_xml(C) || C <- SBOM#sbom.components]},
+            {dependencies, [dependency_to_xml(D) || D <- SBOM#sbom.dependencies]}
+        ]
+    }.
+
+tool_to_xml(Tool) ->
+    {tool, [{name, [Tool]}]}.
+
+component_to_xml(C) ->
+    Attributes = [{type, C#component.type}, {'bom-ref', C#component.bom_ref}],
+    Content = prune_content([
+        component_field_to_xml(author, C#component.author),
+        component_field_to_xml(name, C#component.name),
+        component_field_to_xml(version, C#component.version),
+        component_field_to_xml(description, C#component.description),
+        component_field_to_xml(hashes, C#component.hashes),
+        component_field_to_xml(licenses, C#component.licenses),
+        component_field_to_xml(purl, C#component.purl)
+    ]),
+    {component, Attributes, Content}.
+
+prune_content(Content) ->
+    lists:filter(fun(Field) -> Field =/= undefined end, Content).
+
+component_field_to_xml(_, undefined) ->
+    undefined;
+component_field_to_xml(hashes, Hashes) ->
+    {hashes, [hash_to_xml(Hash) || Hash <- Hashes]};
+component_field_to_xml(licenses, Licenses) ->
+    {licenses, [license_to_xml(License) || License <- Licenses]};
+component_field_to_xml(FieldName, Value) ->
+    {FieldName, [Value]}.
+
+hash_to_xml(#{alg := Alg, hash := Hash}) ->
+    {hash, [{alg, Alg}], [Hash]}.
+
+license_to_xml(#{name := Name}) ->
+    {license, [{name, [Name]}]};
+license_to_xml(#{id := Id}) ->
+    {license, [{id, [Id]}]}.
+
+dependency_to_xml(Dependency) ->
+    {dependency, [{ref, Dependency#dependency.ref}],
+        [dependency_to_xml(D) || D <- Dependency#dependency.dependencies]
+    }.
+
+xml_to_component(Component) ->
+    [#xmlAttribute{value = Type}] = xpath("/component/@type", Component),
+    [#xmlAttribute{value = BomRef}] = xpath("/component/@bom-ref", Component),
+    Author = xpath("/component/author/text()", Component),
+    Name = xpath("/component/name/text()", Component),
+    Version = xpath("/component/version/text()", Component),
+    Description = xpath("/component/description/text()", Component),
+    Purl = xpath("/component/purl/text()", Component),
+    Hashes = [
+        xml_to_hash(H) || H <- xpath("/component/hashes/hash", Component)
+    ],
+    Licenses = [
+        xml_to_license(L) || L <- xpath("/component/licenses/license", Component)
+    ],
+    #component{
+        type = Type,
+        bom_ref = BomRef,
+        author = xml_to_component_field(Author),
+        name = xml_to_component_field(Name),
+        version = xml_to_component_field(Version),
+        description = xml_to_component_field(Description),
+        purl = xml_to_component_field(Purl),
+        hashes = Hashes,
+        licenses = Licenses
+    }.
+
+xml_to_component_field([]) ->
+    undefined;
+xml_to_component_field([#xmlText{value = Value}]) ->
+    Value.
+
+xml_to_hash(HashElement) ->
+    [#xmlText{value = Hash}] = xpath("/hash/text()", HashElement),
+    [#xmlAttribute{value = Alg}] = xpath("/hash/@alg", HashElement),
+    #{hash => Hash, alg => Alg}.
+
+xml_to_license(LicenseElement) ->
+    case xpath("/license/id/text()", LicenseElement) of
+        [Value] ->
+            #{id => Value#xmlText.value};
+        [] ->
+            [Value] = xpath("/license/name/text()", LicenseElement),
+            #{name => Value#xmlText.value}
+    end.
+
+xpath(String, Xml) ->
+    xmerl_xpath:string(String, Xml).


### PR DESCRIPTION
This (admittedly pretty hefty) PR adds support for generating an SBoM in JSON format.
This is achieved by introducing an internal SBoM format based on Erlang records, and then converting that to either XML or JSON.
Old SBoM files are also parsed into the record-based format to check their version and contents.

Existing user-facing behavior is not changed; JSON can be generated by passing the `-F json` argument.

Additionally, two fixes have been made to ensure the generated SBoM files are valid (against both the schema and the [CycloneDX CLI](https://github.com/CycloneDX/cyclonedx-cli)):
- The `serialNumber` field now contains the required `urn:uuid:` prefix.
- Child elements under the `<component>` XML elements are now ordered as the CycloneDX XML spec expects."
